### PR TITLE
Fix/allow select tags keyboard menu

### DIFF
--- a/src/components/VSelect/mixins/select-autocomplete.js
+++ b/src/components/VSelect/mixins/select-autocomplete.js
@@ -101,7 +101,6 @@ export default {
       this.menuIsActive = false
     },
     onKeyDown (e) {
-      console.log('onKeyDown called', e.keyCode, this.menuIsActive)
       // If enter, space, up, or down is pressed, open menu
       if (!this.menuIsActive && [13, 32, 38, 40].includes(e.keyCode)) {
         e.preventDefault()
@@ -121,7 +120,7 @@ export default {
       // Up or down
       if ([38, 40].includes(e.keyCode)) {
         this.selectedIndex = -1
-        // if (this.getMenuIndex() === -1) this.setMenuIndex(0)
+        if (this.getMenuIndex() === -1) this.setMenuIndex(0)
       }
 
       if (this.isAutocomplete &&

--- a/src/components/VSelect/mixins/select-autocomplete.js
+++ b/src/components/VSelect/mixins/select-autocomplete.js
@@ -101,6 +101,7 @@ export default {
       this.menuIsActive = false
     },
     onKeyDown (e) {
+      console.log('onKeyDown called', e.keyCode, this.menuIsActive)
       // If enter, space, up, or down is pressed, open menu
       if (!this.menuIsActive && [13, 32, 38, 40].includes(e.keyCode)) {
         e.preventDefault()
@@ -118,7 +119,10 @@ export default {
       ) this.$refs.menu.changeListIndex(e)
 
       // Up or down
-      if ([38, 40].includes(e.keyCode)) this.selectedIndex = -1
+      if ([38, 40].includes(e.keyCode)) {
+        this.selectedIndex = -1
+        // if (this.getMenuIndex() === -1) this.setMenuIndex(0)
+      }
 
       if (this.isAutocomplete &&
         !this.hideSelections &&


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Simple change to allow a V-Select with tags or combobox to select any of the menu items with the keyboard, if some incompatible props are passed in.